### PR TITLE
Make non match behaviour configurable

### DIFF
--- a/lib/enum.ml
+++ b/lib/enum.ml
@@ -45,27 +45,35 @@ module Str = struct
     in
     Ast_builder.Default.pstr_value ~loc Nonrecursive [value_description]
 
-  let from_string_case_from_constructor ~loc constructor =
+  let from_string_case_from_constructor ~loc ~raises constructor =
     let {pcd_name = {txt = value_name; _}; _} = constructor in
     let lhs = string_to_constant_pattern ~loc ~str:(String.lowercase_ascii value_name) in
-    let rhs = string_to_constructor_expression ~loc ~str:value_name in
-    Ast_builder.Default.case ~lhs ~guard:None ~rhs
-
-  let invalid_case_for_from_string ~loc ~function_name =
-    let lhs = Ast_builder.Default.ppat_any ~loc in
+    let value_t = string_to_constructor_expression ~loc ~str:value_name in
     let rhs =
-      [%expr
-        invalid_arg
-        (__MODULE__ ^ [%e string_to_constant_expression ~loc ~str:("." ^ function_name)])
-      ]
+      if raises then
+        value_t
+      else
+        [%expr Ok [%e value_t]]
     in
     Ast_builder.Default.case ~lhs ~guard:None ~rhs
 
-  let from_string_function ~loc ~type_name ~constructors =
-    let function_name = Utils.from_string_function_name ~enum_name:type_name in
+  let invalid_case_for_from_string ~loc ~raises ~function_name =
+    let lhs = Ast_builder.Default.ppat_any ~loc in
+    let error_message =
+      [%expr __MODULE__ ^ [%e string_to_constant_expression ~loc ~str:("." ^ function_name)]]
+    in
+    let rhs =
+      if raises then
+        [%expr invalid_arg [%e error_message]]
+      else
+        [%expr Error [%e error_message]]
+    in
+    Ast_builder.Default.case ~lhs ~guard:None ~rhs
+
+  let from_string_function_base ~loc ~raises ~function_name ~constructors =
     let pat = Ast_builder.Default.ppat_var ~loc {txt=function_name; loc} in
-    let cases = List.map (from_string_case_from_constructor ~loc) constructors in
-    let cases = cases @ [invalid_case_for_from_string ~loc ~function_name] in
+    let cases = List.map (from_string_case_from_constructor ~loc ~raises) constructors in
+    let cases = cases @ [invalid_case_for_from_string ~loc ~raises ~function_name] in
     let expr = Ast_builder.Default.pexp_function ~loc cases in
     let value_description =
       Ast_builder.Default.value_binding
@@ -75,6 +83,14 @@ module Str = struct
     in
     Ast_builder.Default.pstr_value ~loc Nonrecursive [value_description]
 
+  let from_string_function ~type_name =
+    let function_name = Utils.from_string_function_name ~enum_name:type_name in
+    from_string_function_base ~raises:false ~function_name
+
+  let from_string_exn_function ~type_name =
+    let function_name = Utils.from_string_exn_function_name ~enum_name:type_name in
+    from_string_function_base ~raises:true ~function_name
+
   let from_enummable_variant
     ~loc
     ~type_name
@@ -82,6 +98,7 @@ module Str = struct
   =
     [ to_string_function ~loc ~type_name ~constructors
     ; from_string_function ~loc ~type_name ~constructors
+    ; from_string_exn_function ~loc ~type_name ~constructors
     ]
 
   let from_type_declaration ~loc type_ =
@@ -137,10 +154,16 @@ module Sig = struct
     in
     Ast_builder.Default.psig_value ~loc value_description
 
-  let from_string_function_val ~loc ~type_name =
-    let function_name = Utils.from_string_function_name ~enum_name:type_name in
+  let from_string_function_val_base ~loc ~raises ~function_name ~type_name =
     let type_lident = {txt = Lident type_name; loc} in
-    let rhs_type = Ast_builder.Default.ptyp_constr ~loc type_lident [] in
+    let type_t = Ast_builder.Default.ptyp_constr ~loc type_lident [] in
+    let rhs_type =
+      if raises
+      then
+        type_t
+      else
+        [%type: ([%t type_t], string) result]
+    in
     let type_ = [%type: string -> [%t rhs_type]] in
     let value_description =
       Ast_builder.Default.value_description
@@ -151,10 +174,19 @@ module Sig = struct
     in
     Ast_builder.Default.psig_value ~loc value_description
 
+  let from_string_function_val ~type_name =
+    let function_name = Utils.from_string_function_name ~enum_name:type_name in
+    from_string_function_val_base ~raises:false ~function_name ~type_name
+
+  let from_string_exn_function_val ~type_name =
+    let function_name = Utils.from_string_exn_function_name ~enum_name:type_name in
+    from_string_function_val_base ~raises:true ~function_name ~type_name
+
   let from_enummable_variant ~loc ~type_ =
     let {ptype_name = {txt = type_name; _}; _} = type_ in
     [ to_string_function_val ~loc ~type_name
     ; from_string_function_val ~loc ~type_name
+    ; from_string_exn_function_val ~loc ~type_name
     ]
 
   let from_variant ~loc ~type_ =
@@ -180,6 +212,7 @@ module Sig = struct
   let from_type_decl ~loc ~path:_ (_rec_flag, type_declarations) =
     List.flatten @@ List.map (from_type_declaration ~loc) type_declarations
 end
+
 
 let from_str_type_decl =
   Deriving.Generator.make_noarg Str.from_type_decl

--- a/lib/enum.ml
+++ b/lib/enum.ml
@@ -58,9 +58,15 @@ module Str = struct
     Ast_builder.Default.case ~lhs ~guard:None ~rhs
 
   let invalid_case_for_from_string ~loc ~raises ~function_name =
-    let lhs = Ast_builder.Default.ppat_any ~loc in
+    let lhs = [%pat? s] in
     let error_message =
-      [%expr __MODULE__ ^ [%e string_to_constant_expression ~loc ~str:("." ^ function_name)]]
+      [%expr
+        Printf.sprintf
+          "Unexpected value for %s.%s: %s"
+          __MODULE__
+          [%e string_to_constant_expression ~loc ~str:function_name]
+          s
+      ]
     in
     let rhs =
       if raises then

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -6,6 +6,7 @@ let _prefix_from_enum_name = function
 
 let to_string_function_name ~enum_name = (_prefix_from_enum_name enum_name) ^ "to_string"
 let from_string_function_name ~enum_name = (_prefix_from_enum_name enum_name) ^ "from_string"
+let from_string_exn_function_name ~enum_name = (_prefix_from_enum_name enum_name) ^ "from_string_exn"
 
 let constructor_is_bare constructor =
   match constructor with

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -8,6 +8,11 @@ val to_string_function_name : enum_name: string -> string
  *)
 val from_string_function_name : enum_name: string -> string
 
+(** The from_string_exn function should be named foo_from_string_exn for variant foo, and
+ *  just from_string_exn for the special t variant
+ *)
+val from_string_exn_function_name : enum_name: string -> string
+
 (** Test whether a constructor is a "bare" constructor - that is it is
  *  declared in the form
  *  | Name

--- a/test/deriver/test_enum.expected.ml
+++ b/test/deriver/test_enum.expected.ml
@@ -22,12 +22,18 @@ module S :
       function
       | "foo" -> Ok Foo
       | "bar" -> Ok Bar
-      | _ -> Error (__MODULE__ ^ ".from_string")
+      | s ->
+          Error
+            (Printf.sprintf "Unexpected value for %s.%s: %s" __MODULE__
+               "from_string" s)
     let from_string_exn =
       function
       | "foo" -> Foo
       | "bar" -> Bar
-      | _ -> invalid_arg (__MODULE__ ^ ".from_string_exn")
+      | s ->
+          invalid_arg
+            (Printf.sprintf "Unexpected value for %s.%s: %s" __MODULE__
+               "from_string_exn" s)
     type simple_enum =
       | Foo 
       | Bar [@@deriving enum]
@@ -36,10 +42,16 @@ module S :
       function
       | "foo" -> Ok Foo
       | "bar" -> Ok Bar
-      | _ -> Error (__MODULE__ ^ ".simple_enum_from_string")
+      | s ->
+          Error
+            (Printf.sprintf "Unexpected value for %s.%s: %s" __MODULE__
+               "simple_enum_from_string" s)
     let simple_enum_from_string_exn =
       function
       | "foo" -> Foo
       | "bar" -> Bar
-      | _ -> invalid_arg (__MODULE__ ^ ".simple_enum_from_string_exn")
+      | s ->
+          invalid_arg
+            (Printf.sprintf "Unexpected value for %s.%s: %s" __MODULE__
+               "simple_enum_from_string_exn" s)
   end 

--- a/test/deriver/test_enum.expected.ml
+++ b/test/deriver/test_enum.expected.ml
@@ -1,54 +1,15 @@
-module type Sig_module  =
-  sig
-    type simple_enum =
-      | Foo 
-      | Bar [@@deriving enum]
-    val simple_enum_to_string : simple_enum -> string
-    val simple_enum_from_string : string -> simple_enum
-  end
-module type Sig_module_with_t_type  =
+module S :
   sig
     type t =
       | Foo 
       | Bar [@@deriving enum]
     val to_string : t -> string
     val from_string : string -> t
-  end
-type simple_enum =
-  | Foo 
-  | Bar [@@deriving enum]
-let simple_enum_to_string = function | Foo -> "foo" | Bar -> "bar"
-let simple_enum_from_string =
-  function
-  | "foo" -> Foo
-  | "bar" -> Bar
-  | _ -> invalid_arg (__MODULE__ ^ ".simple_enum_from_string")
-module Sig_module_with_subsequent_implementation :
-  sig
     type simple_enum =
       | Foo 
       | Bar [@@deriving enum]
     val simple_enum_to_string : simple_enum -> string
     val simple_enum_from_string : string -> simple_enum
-  end =
-  struct
-    type simple_enum =
-      | Foo 
-      | Bar [@@deriving enum]
-    let simple_enum_to_string = function | Foo -> "foo" | Bar -> "bar"
-    let simple_enum_from_string =
-      function
-      | "foo" -> Foo
-      | "bar" -> Bar
-      | _ -> invalid_arg (__MODULE__ ^ ".simple_enum_from_string")
-  end 
-module Sig_module_with_subsequent_implementation_and_t_type :
-  sig
-    type t =
-      | Foo 
-      | Bar [@@deriving enum]
-    val to_string : t -> string
-    val from_string : string -> t
   end =
   struct
     type t =
@@ -60,4 +21,13 @@ module Sig_module_with_subsequent_implementation_and_t_type :
       | "foo" -> Foo
       | "bar" -> Bar
       | _ -> invalid_arg (__MODULE__ ^ ".from_string")
+    type simple_enum =
+      | Foo 
+      | Bar [@@deriving enum]
+    let simple_enum_to_string = function | Foo -> "foo" | Bar -> "bar"
+    let simple_enum_from_string =
+      function
+      | "foo" -> Foo
+      | "bar" -> Bar
+      | _ -> invalid_arg (__MODULE__ ^ ".simple_enum_from_string")
   end 

--- a/test/deriver/test_enum.expected.ml
+++ b/test/deriver/test_enum.expected.ml
@@ -4,12 +4,14 @@ module S :
       | Foo 
       | Bar [@@deriving enum]
     val to_string : t -> string
-    val from_string : string -> t
+    val from_string : string -> (t, string) result
+    val from_string_exn : string -> t
     type simple_enum =
       | Foo 
       | Bar [@@deriving enum]
     val simple_enum_to_string : simple_enum -> string
-    val simple_enum_from_string : string -> simple_enum
+    val simple_enum_from_string : string -> (simple_enum, string) result
+    val simple_enum_from_string_exn : string -> simple_enum
   end =
   struct
     type t =
@@ -18,16 +20,26 @@ module S :
     let to_string = function | Foo -> "foo" | Bar -> "bar"
     let from_string =
       function
+      | "foo" -> Ok Foo
+      | "bar" -> Ok Bar
+      | _ -> Error (__MODULE__ ^ ".from_string")
+    let from_string_exn =
+      function
       | "foo" -> Foo
       | "bar" -> Bar
-      | _ -> invalid_arg (__MODULE__ ^ ".from_string")
+      | _ -> invalid_arg (__MODULE__ ^ ".from_string_exn")
     type simple_enum =
       | Foo 
       | Bar [@@deriving enum]
     let simple_enum_to_string = function | Foo -> "foo" | Bar -> "bar"
     let simple_enum_from_string =
       function
+      | "foo" -> Ok Foo
+      | "bar" -> Ok Bar
+      | _ -> Error (__MODULE__ ^ ".simple_enum_from_string")
+    let simple_enum_from_string_exn =
+      function
       | "foo" -> Foo
       | "bar" -> Bar
-      | _ -> invalid_arg (__MODULE__ ^ ".simple_enum_from_string")
+      | _ -> invalid_arg (__MODULE__ ^ ".simple_enum_from_string_exn")
   end 

--- a/test/deriver/test_enum.ml
+++ b/test/deriver/test_enum.ml
@@ -1,41 +1,20 @@
-module type Sig_module = sig
-  type simple_enum =
-    | Foo
-    | Bar
-  [@@deriving enum]
-end
-
-module type Sig_module_with_t_type = sig
+module S : sig
   type t =
     | Foo
     | Bar
   [@@deriving enum]
-end
 
-type simple_enum =
-  | Foo
-  | Bar
-[@@deriving enum]
-
-module Sig_module_with_subsequent_implementation : sig
   type simple_enum =
     | Foo
     | Bar
   [@@deriving enum]
 end = struct
-  type simple_enum =
+  type t =
     | Foo
     | Bar
   [@@deriving enum]
-end
 
-module Sig_module_with_subsequent_implementation_and_t_type : sig
-  type t =
-    | Foo
-    | Bar
-  [@@deriving enum]
-end = struct
-  type t =
+  type simple_enum =
     | Foo
     | Bar
   [@@deriving enum]


### PR DESCRIPTION
This PR enhances `ppx_enum` so that the behaviour of the `from_string` function depends on an optional `raises` flag passed to the `deriving` call (e.g. `[@@deriving enum ~raises]`).

The behaviour of this flag is as follows:
* If the flag is present, then the `from_string` function for enum type `t` will have return type `t`, and will raise an `invalid_arg` error if the passed string does not match any of the options
* If the flag is omitted, then the `from_string` function for enum type `t` will have return type `(t, string) result`, and will return and `Error` if the passed string does not match any of the options