### PR TITLE
Make resulting string configurable

### DIFF
--- a/lib/enum.ml
+++ b/lib/enum.ml
@@ -50,8 +50,7 @@ module Str = struct
 
   let assert_no_duplicate_values ~loc constructor_details =
     let unique_values = List.sort_uniq String.compare @@ snd @@ List.split constructor_details in
-    if List.compare_lengths constructor_details unique_values != 0
-    then
+    if List.compare_lengths constructor_details unique_values != 0 then
         Raise.Enum.errorf ~loc "cannot derive enum. Enums must have unique values"
 
   let to_string_constructor_cases ~loc constructors =
@@ -88,8 +87,9 @@ module Str = struct
     Ast_builder.Default.case ~lhs ~guard:None ~rhs
 
   let from_string_constructor_cases ~loc ~raises constructors =
-    let constructor_details = List.map constructor_name_and_value constructors in
-    List.map (from_string_case_from_name_and_value ~loc ~raises) constructor_details
+    constructors
+    |> List.map constructor_name_and_value
+    |> List.map (from_string_case_from_name_and_value ~loc ~raises)
 
   let invalid_case_for_from_string ~loc ~raises ~function_name =
     let lhs = [%pat? s] in
@@ -232,8 +232,7 @@ module Sig = struct
         )
         value_opts
     in
-    if value_present
-    then
+    if value_present then
       Raise.Enum.errorf ~loc "custom enum values must not be declared in signatures."
 
 
@@ -251,7 +250,7 @@ module Sig = struct
       ; ptype_loc
       ; _
       }
-      when (Utils.constructors_are_bare constructors)
+      when Utils.constructors_are_bare constructors
       ->
         assert_no_values_for_constructors ~loc:ptype_loc constructors;
         from_enummable_variant ~loc:ptype_loc ~type_name

--- a/test/deriver/test_enum.expected.ml
+++ b/test/deriver/test_enum.expected.ml
@@ -12,6 +12,15 @@ module S :
     val simple_enum_to_string : simple_enum -> string
     val simple_enum_from_string : string -> (simple_enum, string) result
     val simple_enum_from_string_exn : string -> simple_enum
+    type enum_with_custom_value =
+      | Foo 
+      | Bar 
+      | Baz [@@deriving enum]
+    val enum_with_custom_value_to_string : enum_with_custom_value -> string
+    val enum_with_custom_value_from_string :
+      string -> (enum_with_custom_value, string) result
+    val enum_with_custom_value_from_string_exn :
+      string -> enum_with_custom_value
   end =
   struct
     type t =
@@ -54,4 +63,28 @@ module S :
           invalid_arg
             (Printf.sprintf "Unexpected value for %s.%s: %s" __MODULE__
                "simple_enum_from_string_exn" s)
+    type enum_with_custom_value =
+      | Foo [@value "foo-1"]
+      | Bar [@enum.value "bar-1"]
+      | Baz [@ppx_enum.enum.value "baz-1"][@@deriving enum]
+    let enum_with_custom_value_to_string =
+      function | Foo -> "foo-1" | Bar -> "bar-1" | Baz -> "baz-1"
+    let enum_with_custom_value_from_string =
+      function
+      | "foo-1" -> Ok Foo
+      | "bar-1" -> Ok Bar
+      | "baz-1" -> Ok Baz
+      | s ->
+          Error
+            (Printf.sprintf "Unexpected value for %s.%s: %s" __MODULE__
+               "enum_with_custom_value_from_string" s)
+    let enum_with_custom_value_from_string_exn =
+      function
+      | "foo-1" -> Foo
+      | "bar-1" -> Bar
+      | "baz-1" -> Baz
+      | s ->
+          invalid_arg
+            (Printf.sprintf "Unexpected value for %s.%s: %s" __MODULE__
+               "enum_with_custom_value_from_string_exn" s)
   end 

--- a/test/deriver/test_enum.ml
+++ b/test/deriver/test_enum.ml
@@ -8,6 +8,12 @@ module S : sig
     | Foo
     | Bar
   [@@deriving enum]
+
+  type enum_with_custom_value =
+    | Foo
+    | Bar
+    | Baz
+  [@@deriving enum]
 end = struct
   type t =
     | Foo
@@ -17,5 +23,11 @@ end = struct
   type simple_enum =
     | Foo
     | Bar
+  [@@deriving enum]
+
+  type enum_with_custom_value =
+    | Foo [@value "foo-1"]
+    | Bar [@enum.value "bar-1"]
+    | Baz [@ppx_enum.enum.value "baz-1"]
   [@@deriving enum]
 end


### PR DESCRIPTION
(This PR is WIP as it depends on #2)

This PR adds the ability for `ppx_enum` users to specify the string value that will be used for a particular option. An example is worth 1000 words here:

```ocaml
type myenum =
  | Foo [@value "baz"]
  | Bar
[@deriving enum]

my_enum_to_string Foo  (* "baz" *)
my_enum_to_string Bar  (* "bar" *)

my_enum_from_string "foo"  (* Error ... *)
my_enum_from_string "bar"  (* Ok Bar *)
my_enum_from_string "baz"  (* Ok Foo *)
```

The attributes will accept any suffix of `ppx_enum.enum.value`, so the following will work:

```ocaml
type myenum =
  | Foo [@value "foo-1"]
  | Bar [@enum.value "bar-1"]
  | Baz [@ppx_enum.enum.value "baz-1"]
[@deriving enum]
```