### PR TITLE
Rename the deriver from enum to str_enum to avoid naming conflicts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v0.0.2
+
+*2019-06-14*
+
+- Rename the deriver from `enum` to `str_enum` to avoid a naming conflict with `ppx_deriving.enum`
+
 ## v0.0.1
 
 *2019-05-27*

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ type my_enum =
   | Foo
   | Bar
   | Baz
-[@@deriving enum]
+[@@deriving str_enum]
 ```
 
-The use of `[@@deriving enum]` will generate the following functions:
+The use of `[@@deriving str_enum]` will generate the following functions:
 
 ```ocaml
 let my_enum_to_string = function
@@ -73,7 +73,7 @@ It is possible to customize the string value that will be used to represent a sp
 type myenum =
   | Foo [@value "baz"]
   | Bar
-[@deriving enum]
+[@deriving str_enum]
 
 my_enum_to_string Foo  (* "baz" *)
 my_enum_to_string Bar  (* "bar" *)
@@ -83,12 +83,12 @@ my_enum_from_string "bar"  (* Ok Bar *)
 my_enum_from_string "baz"  (* Ok Foo *)
 ```
 
-The attributes will accept any valid suffix of `ppx_enum.enum.value`, so the following will work:
+The attributes will accept any valid suffix of `ppx_enum.str_enum.value`, so the following will work:
 
 ```ocaml
 type myenum =
   | Foo [@value "foo-1"]
-  | Bar [@enum.value "bar-1"]
-  | Baz [@ppx_enum.enum.value "baz-1"]
-[@deriving enum]
+  | Bar [@str_enum.value "bar-1"]
+  | Baz [@ppx_enum.str_enum.value "baz-1"]
+[@deriving str_enum]
 ```

--- a/deriver/ppx_enum.ml
+++ b/deriver/ppx_enum.ml
@@ -1,5 +1,5 @@
 let enum =
   Ppxlib.Deriving.add
-    "enum"
+    "str_enum"
     ~str_type_decl:Ppx_enum_lib.Enum.from_str_type_decl
     ~sig_type_decl:Ppx_enum_lib.Enum.from_sig_type_decl

--- a/lib/enum.ml
+++ b/lib/enum.ml
@@ -3,7 +3,7 @@ open Ppxlib
 module Attr = struct
   let value =
     Attribute.declare
-      "ppx_enum.enum.value"
+      "ppx_enum.str_enum.value"
       Attribute.Context.constructor_declaration
       Ast_pattern.(single_expr_payload (estring __))
       (fun x -> x)

--- a/test/deriver/test_enum.expected.ml
+++ b/test/deriver/test_enum.expected.ml
@@ -2,20 +2,20 @@ module S :
   sig
     type t =
       | Foo 
-      | Bar [@@deriving enum]
+      | Bar [@@deriving str_enum]
     val to_string : t -> string
     val from_string : string -> (t, string) result
     val from_string_exn : string -> t
     type simple_enum =
       | Foo 
-      | Bar [@@deriving enum]
+      | Bar [@@deriving str_enum]
     val simple_enum_to_string : simple_enum -> string
     val simple_enum_from_string : string -> (simple_enum, string) result
     val simple_enum_from_string_exn : string -> simple_enum
     type enum_with_custom_value =
       | Foo 
       | Bar 
-      | Baz [@@deriving enum]
+      | Baz [@@deriving str_enum]
     val enum_with_custom_value_to_string : enum_with_custom_value -> string
     val enum_with_custom_value_from_string :
       string -> (enum_with_custom_value, string) result
@@ -25,7 +25,7 @@ module S :
   struct
     type t =
       | Foo 
-      | Bar [@@deriving enum]
+      | Bar [@@deriving str_enum]
     let to_string = function | Foo -> "Foo" | Bar -> "Bar"
     let from_string =
       function
@@ -45,7 +45,7 @@ module S :
                "from_string_exn" s)
     type simple_enum =
       | Foo 
-      | Bar [@@deriving enum]
+      | Bar [@@deriving str_enum]
     let simple_enum_to_string = function | Foo -> "Foo" | Bar -> "Bar"
     let simple_enum_from_string =
       function
@@ -65,8 +65,8 @@ module S :
                "simple_enum_from_string_exn" s)
     type enum_with_custom_value =
       | Foo [@value "foo-1"]
-      | Bar [@enum.value "bar-1"]
-      | Baz [@ppx_enum.enum.value "baz-1"][@@deriving enum]
+      | Bar [@str_enum.value "bar-1"]
+      | Baz [@ppx_enum.str_enum.value "baz-1"][@@deriving str_enum]
     let enum_with_custom_value_to_string =
       function | Foo -> "foo-1" | Bar -> "bar-1" | Baz -> "baz-1"
     let enum_with_custom_value_from_string =

--- a/test/deriver/test_enum.ml
+++ b/test/deriver/test_enum.ml
@@ -2,32 +2,32 @@ module S : sig
   type t =
     | Foo
     | Bar
-  [@@deriving enum]
+  [@@deriving str_enum]
 
   type simple_enum =
     | Foo
     | Bar
-  [@@deriving enum]
+  [@@deriving str_enum]
 
   type enum_with_custom_value =
     | Foo
     | Bar
     | Baz
-  [@@deriving enum]
+  [@@deriving str_enum]
 end = struct
   type t =
     | Foo
     | Bar
-  [@@deriving enum]
+  [@@deriving str_enum]
 
   type simple_enum =
     | Foo
     | Bar
-  [@@deriving enum]
+  [@@deriving str_enum]
 
   type enum_with_custom_value =
     | Foo [@value "foo-1"]
-    | Bar [@enum.value "bar-1"]
-    | Baz [@ppx_enum.enum.value "baz-1"]
-  [@@deriving enum]
+    | Bar [@str_enum.value "bar-1"]
+    | Baz [@ppx_enum.str_enum.value "baz-1"]
+  [@@deriving str_enum]
 end


### PR DESCRIPTION
As a result of the discussions in the [package announcement](https://discuss.ocaml.org/t/ann-ppx-enum-v0-0-1/3875), this MR changes the name of the deriver from `enum` to `str_enum` to avoid the naming conflict with `ppx_deriving.enum`.